### PR TITLE
feat(showcase): prefill selected app login

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -16,11 +16,17 @@ function safeNextPath(value: string | undefined): string {
 export default async function LoginPage({ searchParams }: PageProps) {
   const params = searchParams ? await searchParams : {};
   const nextPath = safeNextPath(firstParam(params.next));
+  const clientId = firstParam(params.client_id);
+  const appName = firstParam(params.app_name);
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-app px-6 py-10">
       <div className="w-full max-w-md">
-        <ClientCredentialsLoginForm nextPath={nextPath} />
+        <ClientCredentialsLoginForm
+          nextPath={nextPath}
+          initialClientId={clientId}
+          appName={appName}
+        />
       </div>
     </main>
   );

--- a/src/components/auth/ClientCredentialsLoginForm.tsx
+++ b/src/components/auth/ClientCredentialsLoginForm.tsx
@@ -3,12 +3,23 @@
 import { FormEvent, useState } from "react";
 import { useRouter } from "next/navigation";
 
-export function ClientCredentialsLoginForm({ nextPath }: { nextPath: string }) {
+type ClientCredentialsLoginFormProps = {
+  nextPath: string;
+  initialClientId?: string;
+  appName?: string;
+};
+
+export function ClientCredentialsLoginForm({
+  nextPath,
+  initialClientId,
+  appName,
+}: ClientCredentialsLoginFormProps) {
   const router = useRouter();
-  const [clientId, setClientId] = useState("");
+  const [clientId, setClientId] = useState(initialClientId ?? "");
   const [clientSecret, setClientSecret] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const selectedAppName = appName?.trim();
 
   async function submitCredentials(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -45,10 +56,18 @@ export function ClientCredentialsLoginForm({ nextPath }: { nextPath: string }) {
       <div className="space-y-2 text-center">
         <div className="text-2xl font-bold text-foreground">Legends of Learning</div>
         <div className="text-sm font-semibold uppercase tracking-wider text-muted">REST API Showcase</div>
-        <h1 className="pt-4 text-3xl font-bold text-foreground">Connect one test app</h1>
+        <h1 className="pt-4 text-3xl font-bold text-foreground">
+          {selectedAppName ? `Connect ${selectedAppName}` : "Connect one test app"}
+        </h1>
         <p className="text-sm leading-6 text-muted">
           Use OAuth client credentials from a Legends app to run the public sample flows locally.
         </p>
+        {initialClientId ? (
+          <div className="mx-auto mt-3 max-w-full rounded-lg border border-border bg-surface-100 px-3 py-2 text-left">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted">Selected app</div>
+            <code className="mt-1 block break-all text-xs text-foreground">{initialClientId}</code>
+          </div>
+        ) : null}
       </div>
 
       {error ? (


### PR DESCRIPTION
## Summary
- accept client_id and app_name on the public showcase login URL
- prefill the client ID and show the selected app name when launched from Legends Console

## Verification
- corepack pnpm exec tsc --noEmit
- corepack pnpm build
- corepack pnpm lint
- local smoke: /login?client_id=test-client-123&app_name=Otus%20Demo&next=%2Fpartners renders Connect Otus Demo and prefilled client ID