### PR TITLE
fix(showcase): accept console session handoff

### DIFF
--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { legendsApiBaseUrl } from "@/lib/server/api-base";
+
+const API_VERSION = process.env.LEGENDS_API_VERSION || "v3";
+
+type SessionPayload = {
+  access_token?: string;
+};
+
+async function validateAccessToken(accessToken: string) {
+  const response = await fetch(`${legendsApiBaseUrl()}/${API_VERSION}/applications/me`, {
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${accessToken}`,
+    },
+    cache: "no-store",
+  });
+
+  return response.ok;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { access_token: accessToken } = (await request.json()) as SessionPayload;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { message: "Access token is required." },
+        { status: 400 }
+      );
+    }
+
+    const valid = await validateAccessToken(accessToken);
+
+    if (!valid) {
+      return NextResponse.json(
+        { message: "The Console session could not be verified." },
+        { status: 401 }
+      );
+    }
+
+    const response = NextResponse.json({ success: true });
+    response.cookies.set("auth_token", accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60,
+      path: "/",
+    });
+
+    return response;
+  } catch (error) {
+    console.error("Session handoff error:", error);
+    return NextResponse.json(
+      { message: "Failed to create showcase session." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/sso/page.tsx
+++ b/src/app/sso/page.tsx
@@ -1,0 +1,5 @@
+import { ShowcaseSsoClient } from "@/components/auth/ShowcaseSsoClient";
+
+export default function ShowcaseSsoPage() {
+  return <ShowcaseSsoClient />;
+}

--- a/src/components/auth/ShowcaseSsoClient.tsx
+++ b/src/components/auth/ShowcaseSsoClient.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+function safeNextPath(value: string | null): string {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) return "/partners";
+  return value;
+}
+
+export function ShowcaseSsoClient() {
+  const router = useRouter();
+  const [message, setMessage] = useState("Opening selected app in the REST API Showcase...");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+    const accessToken = params.get("access_token");
+    const nextPath = safeNextPath(params.get("next"));
+
+    window.history.replaceState(null, "", "/sso");
+
+    if (!accessToken) {
+      setError("Console did not provide a showcase session.");
+      return;
+    }
+
+    let cancelled = false;
+
+    fetch("/api/auth/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ access_token: accessToken }),
+    })
+      .then(async (response) => {
+        const payload = (await response.json().catch(() => ({}))) as { message?: string };
+
+        if (!response.ok) {
+          throw new Error(payload.message || `Session handoff failed with HTTP ${response.status}.`);
+        }
+
+        if (!cancelled) {
+          setMessage("Session ready. Opening showcase...");
+          router.replace(nextPath);
+          router.refresh();
+        }
+      })
+      .catch((handoffError: unknown) => {
+        if (!cancelled) {
+          setError(handoffError instanceof Error ? handoffError.message : "Session handoff failed.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-app px-6 py-10">
+      <section className="w-full max-w-md rounded-2xl border border-border bg-surface p-8 text-center shadow-xl">
+        <div className="text-2xl font-bold text-foreground">Legends of Learning</div>
+        <div className="mt-2 text-sm font-semibold uppercase tracking-wider text-muted">REST API Showcase</div>
+        <h1 className="pt-4 text-3xl font-bold text-foreground">
+          {error ? "Session handoff failed" : "Opening Showcase"}
+        </h1>
+        <p className={`mt-3 text-sm leading-6 ${error ? "text-error" : "text-muted"}`}>
+          {error || message}
+        </p>
+        {error ? (
+          <a href="/login" className="portal-button-secondary mt-6 px-4 py-3 text-sm">
+            Use Client Credentials
+          </a>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/src/components/layout/ConditionalLayout.tsx
+++ b/src/components/layout/ConditionalLayout.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from "@/contexts/theme";
 
 export function ConditionalLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const isFullScreenPage = pathname === "/login";
+  const isFullScreenPage = pathname === "/login" || pathname === "/sso";
 
   if (isFullScreenPage) {
     return (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,7 +8,9 @@ export function middleware(request: NextRequest) {
     request.nextUrl.pathname === '/docs/' ||
     request.nextUrl.pathname === '/api/reference/openapi' ||
     request.nextUrl.pathname === '/login' ||
+    request.nextUrl.pathname === '/sso' ||
     request.nextUrl.pathname === '/api/auth/login' ||
+    request.nextUrl.pathname === '/api/auth/session' ||
     request.nextUrl.pathname === '/api/auth/logout'
   ) {
     return NextResponse.next();


### PR DESCRIPTION
## Summary
- add /sso as the public Showcase session-handoff route
- validate Console-provided access tokens through the backend before setting the Showcase auth cookie
- keep /sso out of the logged-in Showcase shell so handoff states are unambiguous

## Validation
- corepack pnpm exec tsc --noEmit
- corepack pnpm lint (existing img warnings only)
- corepack pnpm build (existing OPENAI_API_KEY warning only)
- local prod smoke: /sso strips token fragment; invalid handoff shows a clear failure; no Client Secret prompt on the SSO screen