### PR TITLE
fix(showcase): use legends api base

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ pnpm install
 Create `.env` in the repo root:
 
 ```env
-LEGENDS_API_URL=https://api.smartlittlecookies.com/api
+LEGENDS_API_URL=https://api.legendsoflearning.com/api
 NEXT_PUBLIC_APP_URL=http://localhost:3000
-NEXT_PUBLIC_LEGENDS_OPENAPI_SPEC_URL=https://api.smartlittlecookies.com/api/v3/docs/openapi
+NEXT_PUBLIC_LEGENDS_OPENAPI_SPEC_URL=https://api.legendsoflearning.com/api/v3/docs/openapi
 ```
 
 The OpenAPI URL is optional and defaults to the production spec above. The app asks for the OAuth client ID and client secret on the local login page. Do not commit credentials or `.env` files.
@@ -127,7 +127,7 @@ chore(docs): update source map
 ## Documentation
 
 - API documentation notes: `docs/api-documentation.md`
-- OpenAPI spec: `https://api.smartlittlecookies.com/api/v3/docs/openapi`
+- OpenAPI spec: `https://api.legendsoflearning.com/api/v3/docs/openapi`
 
 ## License
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1,9 +1,9 @@
 # Legends API Documentation
 
 ## API Overview
-- Base URL: https://api.smartlittlecookies.com/api (production)
+- Base URL: https://api.legendsoflearning.com/api (production)
 - API Version: v3 (automatically added to all requests)
-- OpenAPI Spec: https://api.smartlittlecookies.com/api/v3/docs/openapi
+- OpenAPI Spec: https://api.legendsoflearning.com/api/v3/docs/openapi
 
 ## Authentication
 - Uses 2-legged OAuth (client credentials flow)
@@ -11,7 +11,7 @@
 - The local login page asks for one app's OAuth client ID and client secret. Do not commit those values.
 - `.env` only needs the API base URL for local runs:
   ```
-  LEGENDS_API_URL=https://api.smartlittlecookies.com/api  # No /v3 suffix
+  LEGENDS_API_URL=https://api.legendsoflearning.com/api  # No /v3 suffix
   ```
 
 ## Assignment Creation Flow

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,6 +1,6 @@
 /**
  * API Client for Legends of Learning API
- * OpenAPI Spec: https://api.smartlittlecookies.com/api/v3/docs/openapi
+ * OpenAPI Spec: https://api.legendsoflearning.com/api/v3/docs/openapi
  *
  * SECURITY NOTICE:
  * This is a SERVER-SIDE ONLY client that handles OAuth2 client credentials flow.

--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -9,7 +9,7 @@ import type { AssignmentJoinTarget } from "@/types/api";
  *
  * Example:
  * Frontend request: /api/users
- * Becomes: https://api.smartlittlecookies.com/api/v3/users
+ * Becomes: https://api.legendsoflearning.com/api/v3/users
  *
  * IMPORTANT:
  * 1. Frontend code should NEVER include /v3 in requests
@@ -18,7 +18,7 @@ import type { AssignmentJoinTarget } from "@/types/api";
  */
 
 // Base URL and version from environment variable, with fallback
-const API_BASE_URL = process.env.LEGENDS_API_URL || "https://api.smartlittlecookies.com/api";
+const API_BASE_URL = process.env.LEGENDS_API_URL || "https://api.legendsoflearning.com/api";
 const API_VERSION = process.env.LEGENDS_API_VERSION || "v3";
 
 export const API_ENDPOINTS = {

--- a/src/lib/api/reference.ts
+++ b/src/lib/api/reference.ts
@@ -1,6 +1,6 @@
 export const LEGENDS_OPENAPI_SPEC_URL =
   process.env.NEXT_PUBLIC_LEGENDS_OPENAPI_SPEC_URL ||
-  "https://api.smartlittlecookies.com/api/v3/docs/openapi";
+  "https://api.legendsoflearning.com/api/v3/docs/openapi";
 
 export function openApiOperationUrl(operationId: string): string {
   return `${LEGENDS_OPENAPI_SPEC_URL}#operation/${operationId}`;

--- a/src/lib/chat/tools/api-client.ts
+++ b/src/lib/chat/tools/api-client.ts
@@ -20,7 +20,7 @@ async function apiFetch<T>(endpoint: string, options: RequestInit = {}): Promise
 
   // Build the API URL - endpoint should be like '/searches' or '/content/123'
   // The proxy route expects paths without /api prefix, and adds /v3 automatically
-  const baseUrl = process.env.LEGENDS_API_URL || 'https://api.smartlittlecookies.com/api';
+  const baseUrl = process.env.LEGENDS_API_URL || 'https://api.legendsoflearning.com/api';
   const url = `${baseUrl}/v3${endpoint}`;
   
   const response = await fetch(url, {
@@ -45,7 +45,7 @@ async function apiFetch<T>(endpoint: string, options: RequestInit = {}): Promise
 
 export async function ensureUser(applicationUserId: string, role: 'teacher' | 'student') {
   try {
-    const response = await fetch(`${process.env.LEGENDS_API_URL || 'https://api.smartlittlecookies.com/api'}/v3/users`, {
+    const response = await fetch(`${process.env.LEGENDS_API_URL || 'https://api.legendsoflearning.com/api'}/v3/users`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -75,4 +75,3 @@ export async function ensureUser(applicationUserId: string, role: 'teacher' | 's
 }
 
 export { apiFetch };
-

--- a/src/lib/server/api-base.ts
+++ b/src/lib/server/api-base.ts
@@ -19,7 +19,7 @@ function isLocalApiBase(value: string): boolean {
 export function legendsApiBaseUrl(): string {
   const configuredBase = process.env.LEGENDS_API_URL || "";
   const defaultDevBase = `http://localhost:${detectAiPort()}/api`;
-  const defaultProdBase = "https://api.smartlittlecookies.com/api";
+  const defaultProdBase = "https://api.legendsoflearning.com/api";
 
   if (process.env.NODE_ENV === "development") {
     return stripTrailingSlash(isLocalApiBase(configuredBase) ? configuredBase : defaultDevBase);


### PR DESCRIPTION
## Summary
- update public Showcase defaults from the legacy smartlittlecookies API host to api.legendsoflearning.com
- align OpenAPI links, docs, chat helper defaults, OAuth token requests, and server-side validation with the Console-minted token host

## Validation
- corepack pnpm exec tsc --noEmit
- corepack pnpm lint (existing img warnings only)
- corepack pnpm build (existing OPENAI_API_KEY warning only)
- local prod smoke: Console-minted free-learning-games session token accepted by Showcase /api/auth/session; auth cookie set; /api/applications/me matches the selected app